### PR TITLE
Initialize Photobooth solution

### DIFF
--- a/Photobooth/Photobooth.Adapters/DslrAdapter.cs
+++ b/Photobooth/Photobooth.Adapters/DslrAdapter.cs
@@ -1,0 +1,10 @@
+namespace Photobooth.Adapters
+{
+    public class DslrAdapter
+    {
+        public void Capture()
+        {
+            // TODO: integrate with DSLR Booth
+        }
+    }
+}

--- a/Photobooth/Photobooth.Adapters/Photobooth.Adapters.csproj
+++ b/Photobooth/Photobooth.Adapters/Photobooth.Adapters.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Photobooth.Core\Photobooth.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/Photobooth/Photobooth.App/App.xaml
+++ b/Photobooth/Photobooth.App/App.xaml
@@ -1,0 +1,5 @@
+<Application x:Class="Photobooth.App.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="Views/MainWindow.xaml">
+</Application>

--- a/Photobooth/Photobooth.App/App.xaml.cs
+++ b/Photobooth/Photobooth.App/App.xaml.cs
@@ -1,0 +1,8 @@
+using System.Windows;
+
+namespace Photobooth.App
+{
+    public partial class App : Application
+    {
+    }
+}

--- a/Photobooth/Photobooth.App/Photobooth.App.csproj
+++ b/Photobooth/Photobooth.App/Photobooth.App.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Photobooth.ViewModels\Photobooth.ViewModels.csproj" />
+    <ProjectReference Include="..\Photobooth.Core\Photobooth.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/Photobooth/Photobooth.App/Views/MainWindow.xaml
+++ b/Photobooth/Photobooth.App/Views/MainWindow.xaml
@@ -1,0 +1,8 @@
+<Window x:Class="Photobooth.App.Views.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Photobooth" Height="450" Width="800">
+    <Grid>
+        <TextBlock Text="Photobooth" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="24"/>
+    </Grid>
+</Window>

--- a/Photobooth/Photobooth.App/Views/MainWindow.xaml.cs
+++ b/Photobooth/Photobooth.App/Views/MainWindow.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace Photobooth.App.Views
+{
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/Photobooth/Photobooth.Core/Photobooth.Core.csproj
+++ b/Photobooth/Photobooth.Core/Photobooth.Core.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/Photobooth/Photobooth.Core/RelayCommand.cs
+++ b/Photobooth/Photobooth.Core/RelayCommand.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Windows.Input;
+
+namespace Photobooth.Core
+{
+    public class RelayCommand : ICommand
+    {
+        private readonly Action<object?> _execute;
+        private readonly Predicate<object?>? _canExecute;
+
+        public RelayCommand(Action<object?> execute, Predicate<object?>? canExecute = null)
+        {
+            _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+            _canExecute = canExecute;
+        }
+
+        public bool CanExecute(object? parameter) => _canExecute == null || _canExecute(parameter);
+
+        public void Execute(object? parameter) => _execute(parameter);
+
+        public event EventHandler? CanExecuteChanged;
+
+        public void RaiseCanExecuteChanged()
+        {
+            CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/Photobooth/Photobooth.Core/ViewModelBase.cs
+++ b/Photobooth/Photobooth.Core/ViewModelBase.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Photobooth.Core
+{
+    public abstract class ViewModelBase : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/Photobooth/Photobooth.Integration/Bootstrapper.cs
+++ b/Photobooth/Photobooth.Integration/Bootstrapper.cs
@@ -1,0 +1,10 @@
+namespace Photobooth.Integration
+{
+    public static class Bootstrapper
+    {
+        public static void Initialize()
+        {
+            // TODO: integrate services
+        }
+    }
+}

--- a/Photobooth/Photobooth.Integration/Photobooth.Integration.csproj
+++ b/Photobooth/Photobooth.Integration/Photobooth.Integration.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Photobooth.Services\Photobooth.Services.csproj" />
+  </ItemGroup>
+</Project>

--- a/Photobooth/Photobooth.Models/PhotoSession.cs
+++ b/Photobooth/Photobooth.Models/PhotoSession.cs
@@ -1,0 +1,7 @@
+namespace Photobooth.Models
+{
+    public class PhotoSession
+    {
+        public string? Id { get; set; }
+    }
+}

--- a/Photobooth/Photobooth.Models/Photobooth.Models.csproj
+++ b/Photobooth/Photobooth.Models/Photobooth.Models.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/Photobooth/Photobooth.Resources/Photobooth.Resources.csproj
+++ b/Photobooth/Photobooth.Resources/Photobooth.Resources.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <GenerateResourceResXFileLists>true</GenerateResourceResXFileLists>
+  </PropertyGroup>
+</Project>

--- a/Photobooth/Photobooth.Resources/Strings.resx
+++ b/Photobooth/Photobooth.Resources/Strings.resx
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <data name="Welcome" xml:space="preserve">
+    <value>Welcome to Photobooth</value>
+  </data>
+</root>

--- a/Photobooth/Photobooth.Services/PaymentService.cs
+++ b/Photobooth/Photobooth.Services/PaymentService.cs
@@ -1,0 +1,10 @@
+namespace Photobooth.Services
+{
+    public class PaymentService
+    {
+        public void StartPayment()
+        {
+            // TODO: implement QR or bill acceptor payment
+        }
+    }
+}

--- a/Photobooth/Photobooth.Services/Photobooth.Services.csproj
+++ b/Photobooth/Photobooth.Services/Photobooth.Services.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Photobooth.Models\Photobooth.Models.csproj" />
+    <ProjectReference Include="..\Photobooth.Core\Photobooth.Core.csproj" />
+    <ProjectReference Include="..\Photobooth.Adapters\Photobooth.Adapters.csproj" />
+  </ItemGroup>
+</Project>

--- a/Photobooth/Photobooth.ViewModels/MainViewModel.cs
+++ b/Photobooth/Photobooth.ViewModels/MainViewModel.cs
@@ -1,0 +1,21 @@
+using Photobooth.Core;
+
+namespace Photobooth.ViewModels
+{
+    public class MainViewModel : ViewModelBase
+    {
+        private string _title = "Photobooth";
+        public string Title
+        {
+            get => _title;
+            set
+            {
+                if (_title != value)
+                {
+                    _title = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+    }
+}

--- a/Photobooth/Photobooth.ViewModels/Photobooth.ViewModels.csproj
+++ b/Photobooth/Photobooth.ViewModels/Photobooth.ViewModels.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-windows</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Photobooth.Models\Photobooth.Models.csproj" />
+    <ProjectReference Include="..\Photobooth.Core\Photobooth.Core.csproj" />
+    <ProjectReference Include="..\Photobooth.Services\Photobooth.Services.csproj" />
+  </ItemGroup>
+</Project>

--- a/Photobooth/Photobooth.sln
+++ b/Photobooth/Photobooth.sln
@@ -1,0 +1,22 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Photobooth.App", "Photobooth.App/Photobooth.App.csproj", "{55F4E057-9608-4E44-AC42-04B1300F1891}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Photobooth.ViewModels", "Photobooth.ViewModels/Photobooth.ViewModels.csproj", "{3FDF5FCF-DC67-4340-8FB8-605D1F969782}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Photobooth.Models", "Photobooth.Models/Photobooth.Models.csproj", "{659D61C8-68D5-478E-8A1B-0E2DA4BFA829}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Photobooth.Services", "Photobooth.Services/Photobooth.Services.csproj", "{8AA7ABC4-7061-4F15-9AB0-3E1C302F7C32}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Photobooth.Adapters", "Photobooth.Adapters/Photobooth.Adapters.csproj", "{FC47AF2D-119A-4D9B-A59E-A23A144C116D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Photobooth.Core", "Photobooth.Core/Photobooth.Core.csproj", "{43726A6F-7A15-4F58-9DF8-4938AF619FAC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Photobooth.Integration", "Photobooth.Integration/Photobooth.Integration.csproj", "{6C8DA102-30DC-4326-9E73-40C2AAED7DC7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Photobooth.Resources", "Photobooth.Resources/Photobooth.Resources.csproj", "{FB09A51A-5609-4EDA-96DD-7B72E76F061C}"
+EndProject
+Global
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# tqviet
+# Photobooth
+
+This repository contains a multi-project C# solution structured for a commercial Photobooth application using the MVVM pattern.
+
+## Solution Structure
+
+- `Photobooth.App` - WPF application entry point.
+- `Photobooth.ViewModels` - view models for UI screens.
+- `Photobooth.Models` - domain models.
+- `Photobooth.Services` - business logic services.
+- `Photobooth.Adapters` - hardware adapters (camera, printer, etc.).
+- `Photobooth.Core` - base classes such as `ViewModelBase` and `RelayCommand`.
+- `Photobooth.Integration` - composition and bootstrapping.
+- `Photobooth.Resources` - resource files (strings, images).
+
+The solution file is `Photobooth/Photobooth.sln` which can be opened with Visual Studio.


### PR DESCRIPTION
## Summary
- set up a multi-project Visual Studio solution for the Photobooth app
- add base MVVM classes `ViewModelBase` and `RelayCommand`
- add placeholder projects for models, services, adapters, integration, resources
- provide simple WPF App with a main window
- update README with project structure

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841131e417c8331aca9c9b5b5156620